### PR TITLE
Update Mac Catalyst (x86_64) target

### DIFF
--- a/config/20-apple.conf
+++ b/config/20-apple.conf
@@ -54,7 +54,7 @@ my %targets = ();
     # Based on 10-main.conf: ios-cross
     "mac-catalyst-x86_64" => {
         inherit_from     => [ "darwin64-x86_64-cc", "mac-catalyst-base" ],
-        cflags           => add("-target x86_64-apple-ios13.0-macabi"),
+        cflags           => add("-target x86_64-apple-ios14.0-macabi"),
         sys_id           => "MacOSX",
     },
 


### PR DESCRIPTION
Compiling with Xcode 13.3.1 resulted in "invalid version number in '-target x86_64-apple-ios13.0-macabi'"